### PR TITLE
Code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,5 @@ FakesAssemblies/
 
 *.lock.json
 coverage.xml
+.vs
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ UpgradeLog*.htm
 FakesAssemblies/
 
 *.lock.json
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - cd ./src/Bandwidth.Net && dotnet restore
   - cd ../../test/Bandwidth.Net.Test && dotnet restore    
 script:
-  - dotnet test    
+  - dotnet test -f netcoreapp1.0   

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bandwidth.Net
-[![Build](https://ci.appveyor.com/api/projects/status/bhv8hs3fx9k6c33i?svg=true)](https://ci.appveyor.com/project/avbel/csharp-bandwidth)
+[![Build on .Net 4.5 (Windows)](https://ci.appveyor.com/api/projects/status/bhv8hs3fx9k6c33i?svg=true)](https://ci.appveyor.com/project/avbel/csharp-bandwidth)
+[![Build on .Net Core (Linux)](https://travis-ci.org/bandwidthcom/csharp-bandwidth.svg)](https://travis-ci.org/bandwidthcom/csharp-bandwidth)
+[![Coverage Status](https://coveralls.io/repos/github/bandwidthcom/csharp-bandwidth/badge.svg)](https://coveralls.io/github/bandwidthcom/csharp-bandwidth)
 
 .NET library for [Bandwidth's App Platform](http://ap.bandwidth.com/?utm_medium=social&utm_source=github&utm_campaign=dtolb&utm_content=)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,7 @@ test_script:
     - dotnet build
     - cd bin\Debug\net45\win7-x64
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\ReportGenerator\2.4.5\tools\ReportGenerator.exe -reports:coverage.xml -targetdir:html -reporttypes:TextSummary;Html'
+    - type html\Summary.txt
     - cd ..\..\..\..\..\..
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml --useRelativePaths'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,6 @@ before_test:
     - cd ..\..\test\Bandwidth.Net.Test
     - dotnet restore
     - cd ..\..
-test:
+test_script:
     - cd test\Bandwidth.Net.Test
     - dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+version: 3.0.{build}
+build: off
+
+before_test:
+    - cd src\Bandwidth.Net
+    - dotnet restore
+    - cd ..\..\test\Bandwidth.Net.Test
+    - dotnet restore
+    - cd ..\..
+test:
+    - cd test\Bandwidth.Net.Test
+    - dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ test_script:
     - cd bin\Debug\net45\win7-x64
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
     - cd ..\..\..\..\..\..
-    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml'
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml --useRelativePaths'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,5 @@ test_script:
     - dotnet build
     - cd bin\Debug\net45\win7-x64
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
-    - cd ..\..
+    - cd ..\..\..\..\..\..
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ test_script:
     - cd test\Bandwidth.Net.Test
     - dotnet build
     - cd bin\Debug\net45\win7-x64
-    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll -noshadow" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\ReportGenerator\2.4.5\tools\ReportGenerator.exe -reports:coverage.xml -targetdir:html -reporttypes:TextSummary;Html'
     - type html\Summary.txt
     - cd ..\..\..\..\..\..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
     - dotnet build
     - cd bin\Debug\net45\win7-x64
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll -noshadow" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
-    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\ReportGenerator\2.4.5\tools\ReportGenerator.exe -reports:coverage.xml -targetdir:html -reporttypes:TextSummary;Html'
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\ReportGenerator\2.4.5\tools\ReportGenerator.exe -reports:coverage.xml -targetdir:html -reporttypes:TextSummary'
     - type html\Summary.txt
     - cd ..\..\..\..\..\..
     - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml --useRelativePaths'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ test_script:
     - cd test\Bandwidth.Net.Test
     - dotnet build
     - cd bin\Debug\net45\win7-x64
-    - %HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user'
     - cd ..\..
-    - %HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml
+    - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,4 +9,6 @@ before_test:
     - cd ..\..
 test_script:
     - cd test\Bandwidth.Net.Test
-    - dotnet test
+    - dotnet build
+    - cd bin\Debug\net45\win7-x64
+    - %HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,3 +12,5 @@ test_script:
     - dotnet build
     - cd bin\Debug\net45\win7-x64
     - %HOMEDRIVE%%HOMEPATH%\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe -target:"%HOMEDRIVE%%HOMEPATH%\.nuget\packages\xunit.runner.console\2.1.0\tools\xunit.console.exe" -targetargs:"Bandwidth.Net.Test.dll" -output:coverage.xml -skipautoprops -returntargetcode -filter:"+[Bandwidth*]* -[*Test]*" -searchdirs:"." -register:user
+    - cd ..\..
+    - %HOMEDRIVE%%HOMEPATH%\.nuget\packages\coveralls.net\0.6.0\tools\csmacnz.Coveralls.exe --opencover -i test\Bandwidth.Net.Test\bin\Debug\net45\win7-x64\coverage.xml

--- a/src/Bandwidth.Net/Client.cs
+++ b/src/Bandwidth.Net/Client.cs
@@ -11,7 +11,7 @@ namespace Bandwidth.Net
 {
   public class Client
   {
-    private readonly string _userId;
+    internal readonly string UserId;
     private readonly IHttp _http;
     private static readonly ProductInfoHeaderValue _userAgent = BuildUserAgent();
     private readonly AuthenticationHeaderValue _authentication;
@@ -24,7 +24,7 @@ namespace Bandwidth.Net
       {
         throw new MissingCredentialsException();
       }
-      _userId = userId;
+      UserId = userId;
       _http = http ?? new Http();
       _authentication =
           new AuthenticationHeaderValue("Basic",

--- a/src/Bandwidth.Net/Client.cs
+++ b/src/Bandwidth.Net/Client.cs
@@ -25,7 +25,7 @@ namespace Bandwidth.Net
         throw new MissingCredentialsException();
       }
       UserId = userId;
-      _http = http ?? new Http();
+      _http = http ?? new Http<HttpClientHandler>();
       _authentication =
           new AuthenticationHeaderValue("Basic",
               Convert.ToBase64String(Encoding.UTF8.GetBytes($"{apiToken}:{apiSecret}")));

--- a/src/Bandwidth.Net/Http.cs
+++ b/src/Bandwidth.Net/Http.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,11 +9,11 @@ namespace Bandwidth.Net
     Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken);
   }
 
-  internal class Http : IHttp
+  internal class Http<THandler> : IHttp where THandler : HttpMessageHandler, new()
   {
     public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
     {
-      using (var client = new HttpClient())
+      using (var client = new HttpClient(new THandler(), true))
       {
         return await client.SendAsync(request, completionOption, cancellationToken);
       }

--- a/src/Bandwidth.Net/project.json
+++ b/src/Bandwidth.Net/project.json
@@ -13,11 +13,17 @@
       }
     },
     "net45": {
+      "buildOptions": {
+        "debugType": "full"
+      },
       "dependencies": {
         "System.Net.Http": "4.*"
       }
     },
     "net46": {
+      "buildOptions": {
+        "debugType": "full"
+      },
       "dependencies": {
         "System.Net.Http": "4.*"
       }

--- a/test/Bandwidth.Net.Test/HttpTests.cs
+++ b/test/Bandwidth.Net.Test/HttpTests.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 
 namespace Bandwidth.Net.Test
 {
-  public class HttpTests
+  /*public class HttpTests
   {
     [Fact]
     public async void TestSendAsync()
@@ -26,5 +26,5 @@ namespace Bandwidth.Net.Test
       task.Wait();
       listener.Stop();
     }
-  }
+  }*/
 }

--- a/test/Bandwidth.Net.Test/HttpTests.cs
+++ b/test/Bandwidth.Net.Test/HttpTests.cs
@@ -1,30 +1,29 @@
 using Xunit;
 using System.Net;
-using System.Threading;
-using System.Net.Sockets;
-using System.Text;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Bandwidth.Net.Test
 {
-  /*public class HttpTests
+  public class HttpTests
   {
     [Fact]
     public async void TestSendAsync()
     {
-      var http = new Http();
-      var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:9988");
-      var listener = new TcpListener(IPAddress.Loopback, 9988);
-      listener.Start();
-      var task = listener.AcceptSocketAsync().ContinueWith(t =>
-      {
-        var socket = t.Result;
-        socket.Send(Encoding.UTF8.GetBytes("HTTP/1.1 204 OK\n\n"));
-      });
-      var response = await http.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-      Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-      task.Wait();
-      listener.Stop();
+      var http = new Http<TestMessageHandler>();
+      var response = await http.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost/"), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+      Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
-  }*/
+
+    private class TestMessageHandler : HttpMessageHandler
+    {
+      protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+      {
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal("http://localhost/", request.RequestUri.ToString());
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("Test") });
+      }
+    }
+  }
 }

--- a/test/Bandwidth.Net.Test/project.json
+++ b/test/Bandwidth.Net.Test/project.json
@@ -4,17 +4,24 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Bandwidth.Net": {
       "target": "project"
     }
   },
   "testRunner": "xunit",
   "frameworks": {
+    "net45": {
+      "dependencies": {
+        "LightMock": "1.0.0.6",
+        "OpenCover": "4.6.519",
+        "xunit.runner.console":  "2.1.0"
+      }
+    },
     "netcoreapp1.0": {
       "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0"

--- a/test/Bandwidth.Net.Test/project.json
+++ b/test/Bandwidth.Net.Test/project.json
@@ -15,7 +15,9 @@
       "dependencies": {
         "LightMock": "1.0.0.6",
         "OpenCover": "4.6.519",
-        "xunit.runner.console":  "2.1.0"
+        "xunit.runner.console": "2.1.0",
+        "System.Runtime": "4.0.0.0",
+        "System.Threading.Tasks": "4.0.0.0"
       }
     },
     "netcoreapp1.0": {

--- a/test/Bandwidth.Net.Test/project.json
+++ b/test/Bandwidth.Net.Test/project.json
@@ -19,6 +19,7 @@
         "LightMock": "1.0.0.6",
         "OpenCover": "4.6.519",
         "coveralls.net": "0.6.0",
+        "ReportGenerator": "2.4.5",
         "xunit.runner.console": "2.1.0",
         "System.Runtime": "4.0.0.0",
         "System.Threading.Tasks": "4.0.0.0"

--- a/test/Bandwidth.Net.Test/project.json
+++ b/test/Bandwidth.Net.Test/project.json
@@ -18,6 +18,7 @@
       "dependencies": {
         "LightMock": "1.0.0.6",
         "OpenCover": "4.6.519",
+        "coveralls.net": "0.6.0",
         "xunit.runner.console": "2.1.0",
         "System.Runtime": "4.0.0.0",
         "System.Threading.Tasks": "4.0.0.0"

--- a/test/Bandwidth.Net.Test/project.json
+++ b/test/Bandwidth.Net.Test/project.json
@@ -12,6 +12,9 @@
   "testRunner": "xunit",
   "frameworks": {
     "net45": {
+      "buildOptions": {
+        "debugType": "full"
+      },
       "dependencies": {
         "LightMock": "1.0.0.6",
         "OpenCover": "4.6.519",


### PR DESCRIPTION
Now tests are ran on Travis (.Net Core 1.0 on Linux) and AppVeyor (.Net 4.5 on Windows). In second case coverage report is generated and sent to `coveralls.io`. Also now 100% of code is covered.

![image](https://cloud.githubusercontent.com/assets/3050652/17401891/e39e8328-5a58-11e6-8bd2-9116bb9c8276.png)

![image](https://cloud.githubusercontent.com/assets/3050652/17401922/145716ba-5a59-11e6-8127-369fa9b08fcf.png)


![image](https://cloud.githubusercontent.com/assets/3050652/17401962/4ab2e66c-5a59-11e6-9b94-4791db88da59.png)


1 non-fixed "issues": Coverall shows unknown state on badge even after adding badge to README.md 