### PR TITLE
Callback events support

### DIFF
--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -7,202 +7,213 @@ using Newtonsoft.Json;
 namespace Bandwidth.Net
 {
   /// <summary>
-  /// Catapult Api callback event
+  ///   Catapult Api callback event
   /// </summary>
+  /// <example>
+  /// <code>
+  /// var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"sms\"}");
+  /// switch(callbackEvent.EventType)
+  /// {
+  ///   case CallbackEventTypes.Sms:
+  ///     Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
+  ///     break;
+  /// }
+  /// </code>
+  /// </example>
   public class CallbackEvent
   {
     /// <summary>
-    /// Event type
+    ///   Event type
     /// </summary>
     public CallbackEventTypes EventType { get; set; }
 
     /// <summary>
-    /// Message direction
+    ///   Message direction
     /// </summary>
     public MessageDirection Direction { get; set; }
 
     /// <summary>
-    /// From
+    ///   From
     /// </summary>
     public string From { get; set; }
 
     /// <summary>
-    /// To
+    ///   To
     /// </summary>
     public string To { get; set; }
 
     /// <summary>
-    /// Id of message
+    ///   Id of message
     /// </summary>
     public string MessageId { get; set; }
 
     /// <summary>
-    /// Url to message
+    ///   Url to message
     /// </summary>
     public string MessageUri { get; set; }
 
     /// <summary>
-    /// Text of message or transcription
+    ///   Text of message or transcription
     /// </summary>
     public string Text { get; set; }
 
     /// <summary>
-    /// Application Id
+    ///   Application Id
     /// </summary>
     public string ApplicationId { get; set; }
 
     /// <summary>
-    /// Time
+    ///   Time
     /// </summary>
     public DateTime Time { get; set; }
 
     /// <summary>
-    /// State
+    ///   State
     /// </summary>
     public CallbackEventStates State { get; set; }
 
     /// <summary>
-    /// Delivery state of message
+    ///   Delivery state of message
     /// </summary>
     public MessageDeliveryState DeliveryState { get; set; }
 
     /// <summary>
-    /// Delivery code of message
+    ///   Delivery code of message
     /// </summary>
     public int DeliveryCode { get; set; }
 
     /// <summary>
-    /// Delivery description of message
+    ///   Delivery description of message
     /// </summary>
     public string DeliveryDescription { get; set; }
 
     /// <summary>
-    /// Urls to attached media files to message
+    ///   Urls to attached media files to message
     /// </summary>
     public string[] Media { get; set; }
 
     /// <summary>
-    /// Call state
+    ///   Call state
     /// </summary>
     public CallState CallState { get; set; }
 
     /// <summary>
-    /// Id of call
+    ///   Id of call
     /// </summary>
     public string CallId { get; set; }
 
     /// <summary>
-    /// Url to the call
+    ///   Url to the call
     /// </summary>
     public string CallUri { get; set; }
 
     /// <summary>
-    /// Tag
+    ///   Tag
     /// </summary>
     public string Tag { get; set; }
 
     /// <summary>
-    /// Status
+    ///   Status
     /// </summary>
     public CallbackEventStatus Status { get; set; }
 
     /// <summary>
-    /// If of conference
+    ///   If of conference
     /// </summary>
     public string ConferenceId { get; set; }
 
     /// <summary>
-    /// Url to the conference
+    ///   Url to the conference
     /// </summary>
     public string ConferenceUri { get; set; }
 
     /// <summary>
-    /// Created time of the conference
+    ///   Created time of the conference
     /// </summary>
     public DateTime CreatedTime { get; set; }
 
     /// <summary>
-    /// Completed time of the conference
+    ///   Completed time of the conference
     /// </summary>
     public DateTime CompletedTime { get; set; }
 
     /// <summary>
-    /// Active mebers count of the conference
+    ///   Active mebers count of the conference
     /// </summary>
     public int ActiveMembers { get; set; }
 
     /// <summary>
-    /// Id of conference member
+    ///   Id of conference member
     /// </summary>
     public string MemberId { get; set; }
 
     /// <summary>
-    /// Url to the conference member
+    ///   Url to the conference member
     /// </summary>
     public string MemberUri { get; set; }
 
     /// <summary>
-    /// Members is on hold in conference and can not hear or speak.
+    ///   Members is on hold in conference and can not hear or speak.
     /// </summary>
     public bool Hold { get; set; }
 
     /// <summary>
-    /// Members audio is muted in conference.
+    ///   Members audio is muted in conference.
     /// </summary>
     public bool Mute { get; set; }
 
     /// <summary>
-    /// The digit pressed
+    ///   The digit pressed
     /// </summary>
     public string DtmfDigit { get; set; }
 
     /// <summary>
-    /// Id of gather
+    ///   Id of gather
     /// </summary>
     public string GatherId { get; set; }
 
     /// <summary>
-    /// Reason
+    ///   Reason
     /// </summary>
     public CallbackEventReason Reason { get; set; }
 
     /// <summary>
-    /// Cause of call termination
+    ///   Cause of call termination
     /// </summary>
     public string Cause { get; set; }
 
     /// <summary>
-    /// Id of recording
+    ///   Id of recording
     /// </summary>
     public string RecordingId { get; set; }
 
     /// <summary>
-    /// Url to the recording
+    ///   Url to the recording
     /// </summary>
     public string RecordingUri { get; set; }
 
     /// <summary>
-    /// Id of transcription
+    ///   Id of transcription
     /// </summary>
     public string TranscriptionId { get; set; }
 
     /// <summary>
-    /// Url to the transcription
+    ///   Url to the transcription
     /// </summary>
     public string TranscriptionUri { get; set; }
 
     /// <summary>
-    /// Total character count of text.
+    ///   Total character count of text.
     /// </summary>
     public int TextSize { get; set; }
 
     /// <summary>
-    /// The full URL of the entire text content of the transcription.
+    ///   The full URL of the entire text content of the transcription.
     /// </summary>
     public string TextUrl { get; set; }
 
     /// <summary>
-    /// Create instance from JSON string
+    ///   Create instance from JSON string
     /// </summary>
     /// <param name="json">JSON string with callback event data</param>
     /// <returns>New instance of CallbackEvent</returns>
@@ -211,227 +222,236 @@ namespace Bandwidth.Net
   }
 
   /// <summary>
-  /// Possible event types
+  ///   Possible event types
   /// </summary>
   public enum CallbackEventTypes
   {
     /// <summary>
-    /// Unknown type
+    ///   Unknown type
     /// </summary>
     Unknown,
 
     /// <summary>
-    /// Sms
+    ///   Sms
     /// </summary>
     Sms,
 
     /// <summary>
-    /// Mms
+    ///   Mms
     /// </summary>
     Mms,
 
     /// <summary>
-    /// Answer call
+    ///   Answer call
     /// </summary>
     Answer,
 
     /// <summary>
-    /// Playback uadio
+    ///   Playback uadio
     /// </summary>
     Playback,
 
     /// <summary>
-    /// Call timeout
+    ///   Call timeout
     /// </summary>
     Timeout,
 
     /// <summary>
-    /// Conference
+    ///   Conference
     /// </summary>
     Conference,
 
     /// <summary>
-    /// Play audio to the conference
+    ///   Play audio to the conference
     /// </summary>
     ConferencePlayback,
 
     /// <summary>
-    /// Conference member
+    ///   Conference member
     /// </summary>
     ConferenceMember,
 
     /// <summary>
-    /// Speak text to the conference
+    ///   Speak text to the conference
     /// </summary>
     ConferenceSpeak,
 
     /// <summary>
-    /// DTMF
+    ///   DTMF
     /// </summary>
     Dtmf,
 
     /// <summary>
-    /// Gather
+    ///   Gather
     /// </summary>
     Gather,
 
     /// <summary>
-    /// Incoming call
+    ///   Incoming call
     /// </summary>
     Incomingcall,
 
     /// <summary>
-    /// Call completed
+    ///   Call completed
     /// </summary>
     Hangup,
 
     /// <summary>
-    /// Recording
+    ///   Recording
     /// </summary>
     Recording,
 
     /// <summary>
-    /// Speak text
+    ///   Speak text
     /// </summary>
     Speak,
 
     /// <summary>
-    /// Transcription
+    ///   Transcription
     /// </summary>
     Transcription
   }
 
   /// <summary>
-  /// Possible statuses of calback events
+  ///   Possible statuses of calback events
   /// </summary>
   public enum CallbackEventStatus
   {
     /// <summary>
-    /// Started
+    ///   Started
     /// </summary>
     Started,
 
     /// <summary>
-    /// Done
+    ///   Done
     /// </summary>
     Done,
 
     /// <summary>
-    /// Created
+    ///   Created
     /// </summary>
     Created,
 
     /// <summary>
-    /// Completed
+    ///   Completed
     /// </summary>
     Completed,
 
     /// <summary>
-    /// Complete
+    ///   Complete
     /// </summary>
     Complete,
 
     /// <summary>
-    /// Error
+    ///   Error
     /// </summary>
     Error
   }
 
   /// <summary>
-  /// Callback event states
+  ///   Callback event states
   /// </summary>
   public enum CallbackEventStates
   {
     /// <summary>
-    /// Active
+    ///   Active
     /// </summary>
     Active,
 
     /// <summary>
-    /// Completed
+    ///   Completed
     /// </summary>
     Completed,
 
     /// <summary>
-    /// Received
+    ///   Received
     /// </summary>
     Received,
 
     /// <summary>
-    /// Queued
+    ///   Queued
     /// </summary>
     Queued,
 
     /// <summary>
-    /// Sending
+    ///   Sending
     /// </summary>
     Sending,
 
     /// <summary>
-    /// Sent
+    ///   Sent
     /// </summary>
     Sent,
 
     /// <summary>
-    /// Complete
+    ///   Complete
     /// </summary>
     Complete,
 
     /// <summary>
-    /// Error
+    ///   Error
     /// </summary>
     Error,
 
     /// <summary>
-    /// Start of playback
+    ///   Start of playback
     /// </summary>
     PlaybackStart,
 
     /// <summary>
-    /// End of playback
+    ///   End of playback
     /// </summary>
     PlaybackStop
   }
 
   /// <summary>
-  /// Possible reasons of calback events
+  ///   Possible reasons of calback events
   /// </summary>
   public enum CallbackEventReason
   {
     /// <summary>
-    /// Max digits reached
+    ///   Max digits reached
     /// </summary>
     MaxDigits,
 
     /// <summary>
-    /// Terminating digit
+    ///   Terminating digit
     /// </summary>
     TerminatingDigit,
 
     /// <summary>
-    /// Interdigit timeout
+    ///   Interdigit timeout
     /// </summary>
     InterDigitTimeout,
 
     /// <summary>
-    /// Hung up
+    ///   Hung up
     /// </summary>
     HungUp
   }
 
   /// <summary>
-  /// Helper for HttpContent to parse CallbackEvent
+  ///   Helper for HttpContent to parse CallbackEvent
   /// </summary>
   public static class CallbackEventHelpers
   {
     /// <summary>
-    /// Read CallbackEvent instance from http content
+    ///   Read CallbackEvent instance from http content
     /// </summary>
     /// <param name="content">Content</param>
     /// <returns>Callback event data or null if response content is not json</returns>
+    /// <example>
+    /// <code>
+    /// var callbackEvent = await response.Content.ReadAsCallbackEventAsync(); // response is instance of HttpResponseEvent
+    /// switch(callbackEvent.EventType)
+    /// {
+    ///   case CallbackEventTypes.Sms:
+    ///     Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
+    ///     break;
+    /// }
+    /// </code>
+    /// </example>
     public static Task<CallbackEvent> ReadAsCallbackEventAsync(this HttpContent content)
-    {
-      return content.ReadAsJsonAsync<CallbackEvent>();
-    }
+      => content.ReadAsJsonAsync<CallbackEvent>();
   }
 }

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -14,7 +14,7 @@ namespace Bandwidth.Net
     /// <summary>
     /// Event type
     /// </summary>
-    public EventTypes EventType { get; set; }
+    public CallbackEventTypes EventType { get; set; }
 
     /// <summary>
     /// Message direction
@@ -213,7 +213,7 @@ namespace Bandwidth.Net
   /// <summary>
   /// Possible event types
   /// </summary>
-  public enum EventTypes
+  public enum CallbackEventTypes
   {
     /// <summary>
     /// Unknown type

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -25,7 +25,7 @@ namespace Bandwidth.Net
     /// <summary>
     ///   Event type
     /// </summary>
-    public CallbackEventTypes EventType { get; set; }
+    public CallbackEventType EventType { get; set; }
 
     /// <summary>
     ///   Message direction
@@ -70,7 +70,7 @@ namespace Bandwidth.Net
     /// <summary>
     ///   State
     /// </summary>
-    public CallbackEventStates State { get; set; }
+    public CallbackEventState State { get; set; }
 
     /// <summary>
     ///   Delivery state of message
@@ -224,7 +224,7 @@ namespace Bandwidth.Net
   /// <summary>
   ///   Possible event types
   /// </summary>
-  public enum CallbackEventTypes
+  public enum CallbackEventType
   {
     /// <summary>
     ///   Unknown type
@@ -351,7 +351,7 @@ namespace Bandwidth.Net
   /// <summary>
   ///   Callback event states
   /// </summary>
-  public enum CallbackEventStates
+  public enum CallbackEventState
   {
     /// <summary>
     ///   Active

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -1,0 +1,437 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Bandwidth.Net.Api;
+using Newtonsoft.Json;
+
+namespace Bandwidth.Net
+{
+  /// <summary>
+  /// Catapult Api callback event
+  /// </summary>
+  public class CallbackEvent
+  {
+    /// <summary>
+    /// Event type
+    /// </summary>
+    public EventTypes EventType { get; set; }
+
+    /// <summary>
+    /// Message direction
+    /// </summary>
+    public MessageDirection Direction { get; set; }
+
+    /// <summary>
+    /// From
+    /// </summary>
+    public string From { get; set; }
+
+    /// <summary>
+    /// To
+    /// </summary>
+    public string To { get; set; }
+
+    /// <summary>
+    /// Id of message
+    /// </summary>
+    public string MessageId { get; set; }
+
+    /// <summary>
+    /// Url to message
+    /// </summary>
+    public string MessageUri { get; set; }
+
+    /// <summary>
+    /// Text of message or transcription
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Application Id
+    /// </summary>
+    public string ApplicationId { get; set; }
+
+    /// <summary>
+    /// Time
+    /// </summary>
+    public DateTime Time { get; set; }
+
+    /// <summary>
+    /// State
+    /// </summary>
+    public CallbackEventStates State { get; set; }
+
+    /// <summary>
+    /// Delivery state of message
+    /// </summary>
+    public MessageDeliveryState DeliveryState { get; set; }
+
+    /// <summary>
+    /// Delivery code of message
+    /// </summary>
+    public int DeliveryCode { get; set; }
+
+    /// <summary>
+    /// Delivery description of message
+    /// </summary>
+    public string DeliveryDescription { get; set; }
+
+    /// <summary>
+    /// Urls to attached media files to message
+    /// </summary>
+    public string[] Media { get; set; }
+
+    /// <summary>
+    /// Call state
+    /// </summary>
+    public CallState CallState { get; set; }
+
+    /// <summary>
+    /// Id of call
+    /// </summary>
+    public string CallId { get; set; }
+
+    /// <summary>
+    /// Url to the call
+    /// </summary>
+    public string CallUri { get; set; }
+
+    /// <summary>
+    /// Tag
+    /// </summary>
+    public string Tag { get; set; }
+
+    /// <summary>
+    /// Status
+    /// </summary>
+    public CallbackEventStatus Status { get; set; }
+
+    /// <summary>
+    /// If of conference
+    /// </summary>
+    public string ConferenceId { get; set; }
+
+    /// <summary>
+    /// Url to the conference
+    /// </summary>
+    public string ConferenceUri { get; set; }
+
+    /// <summary>
+    /// Created time of the conference
+    /// </summary>
+    public DateTime CreatedTime { get; set; }
+
+    /// <summary>
+    /// Completed time of the conference
+    /// </summary>
+    public DateTime CompletedTime { get; set; }
+
+    /// <summary>
+    /// Active mebers count of the conference
+    /// </summary>
+    public int ActiveMembers { get; set; }
+
+    /// <summary>
+    /// Id of conference member
+    /// </summary>
+    public string MemberId { get; set; }
+
+    /// <summary>
+    /// Url to the conference member
+    /// </summary>
+    public string MemberUri { get; set; }
+
+    /// <summary>
+    /// Members is on hold in conference and can not hear or speak.
+    /// </summary>
+    public bool Hold { get; set; }
+
+    /// <summary>
+    /// Members audio is muted in conference.
+    /// </summary>
+    public bool Mute { get; set; }
+
+    /// <summary>
+    /// The digit pressed
+    /// </summary>
+    public string DtmfDigit { get; set; }
+
+    /// <summary>
+    /// Id of gather
+    /// </summary>
+    public string GatherId { get; set; }
+
+    /// <summary>
+    /// Reason
+    /// </summary>
+    public CallbackEventReason Reason { get; set; }
+
+    /// <summary>
+    /// Cause of call termination
+    /// </summary>
+    public string Cause { get; set; }
+
+    /// <summary>
+    /// Id of recording
+    /// </summary>
+    public string RecordingId { get; set; }
+
+    /// <summary>
+    /// Url to the recording
+    /// </summary>
+    public string RecordingUri { get; set; }
+
+    /// <summary>
+    /// Id of transcription
+    /// </summary>
+    public string TranscriptionId { get; set; }
+
+    /// <summary>
+    /// Url to the transcription
+    /// </summary>
+    public string TranscriptionUri { get; set; }
+
+    /// <summary>
+    /// Total character count of text.
+    /// </summary>
+    public int TextSize { get; set; }
+
+    /// <summary>
+    /// The full URL of the entire text content of the transcription.
+    /// </summary>
+    public string TextUrl { get; set; }
+
+    /// <summary>
+    /// Create instance from JSON string
+    /// </summary>
+    /// <param name="json">JSON string with callback event data</param>
+    /// <returns>New instance of CallbackEvent</returns>
+    public static CallbackEvent CreateFromJson(string json)
+      => JsonConvert.DeserializeObject<CallbackEvent>(json, JsonHelpers.GetSerializerSettings());
+  }
+
+  /// <summary>
+  /// Possible event types
+  /// </summary>
+  public enum EventTypes
+  {
+    /// <summary>
+    /// Unknown type
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// Sms
+    /// </summary>
+    Sms,
+
+    /// <summary>
+    /// Mms
+    /// </summary>
+    Mms,
+
+    /// <summary>
+    /// Answer call
+    /// </summary>
+    Answer,
+
+    /// <summary>
+    /// Playback uadio
+    /// </summary>
+    Playback,
+
+    /// <summary>
+    /// Call timeout
+    /// </summary>
+    Timeout,
+
+    /// <summary>
+    /// Conference
+    /// </summary>
+    Conference,
+
+    /// <summary>
+    /// Play audio to the conference
+    /// </summary>
+    ConferencePlayback,
+
+    /// <summary>
+    /// Conference member
+    /// </summary>
+    ConferenceMember,
+
+    /// <summary>
+    /// Speak text to the conference
+    /// </summary>
+    ConferenceSpeak,
+
+    /// <summary>
+    /// DTMF
+    /// </summary>
+    Dtmf,
+
+    /// <summary>
+    /// Gather
+    /// </summary>
+    Gather,
+
+    /// <summary>
+    /// Incoming call
+    /// </summary>
+    Incomingcall,
+
+    /// <summary>
+    /// Call completed
+    /// </summary>
+    Hangup,
+
+    /// <summary>
+    /// Recording
+    /// </summary>
+    Recording,
+
+    /// <summary>
+    /// Speak text
+    /// </summary>
+    Speak,
+
+    /// <summary>
+    /// Transcription
+    /// </summary>
+    Transcription
+  }
+
+  /// <summary>
+  /// Possible statuses of calback events
+  /// </summary>
+  public enum CallbackEventStatus
+  {
+    /// <summary>
+    /// Started
+    /// </summary>
+    Started,
+
+    /// <summary>
+    /// Done
+    /// </summary>
+    Done,
+
+    /// <summary>
+    /// Created
+    /// </summary>
+    Created,
+
+    /// <summary>
+    /// Completed
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// Complete
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    /// Error
+    /// </summary>
+    Error
+  }
+
+  /// <summary>
+  /// Callback event states
+  /// </summary>
+  public enum CallbackEventStates
+  {
+    /// <summary>
+    /// Active
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Completed
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// Received
+    /// </summary>
+    Received,
+
+    /// <summary>
+    /// Queued
+    /// </summary>
+    Queued,
+
+    /// <summary>
+    /// Sending
+    /// </summary>
+    Sending,
+
+    /// <summary>
+    /// Sent
+    /// </summary>
+    Sent,
+
+    /// <summary>
+    /// Complete
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    /// Error
+    /// </summary>
+    Error,
+
+    /// <summary>
+    /// Start of playback
+    /// </summary>
+    PlaybackStart,
+
+    /// <summary>
+    /// End of playback
+    /// </summary>
+    PlaybackStop
+  }
+
+  /// <summary>
+  /// Possible reasons of calback events
+  /// </summary>
+  public enum CallbackEventReason
+  {
+    /// <summary>
+    /// Max digits reached
+    /// </summary>
+    MaxDigits,
+
+    /// <summary>
+    /// Terminating digit
+    /// </summary>
+    TerminatingDigit,
+
+    /// <summary>
+    /// Interdigit timeout
+    /// </summary>
+    InterDigitTimeout,
+
+    /// <summary>
+    /// Hung up
+    /// </summary>
+    HungUp
+  }
+
+  /// <summary>
+  /// Helper for HttpResponseMessage to parse CallbackEvent
+  /// </summary>
+  public static class CallbackEventHelpers
+  {
+    /// <summary>
+    /// Read CallbackEvent instance from response content
+    /// </summary>
+    /// <param name="response">Response</param>
+    /// <returns>Callback event data or null if response content is not json</returns>
+    public static Task<CallbackEvent> ReadAsCallbackEventAsync(this HttpResponseMessage response)
+    {
+      return response.ReadAsJsonAsync<CallbackEvent>();
+    }
+  }
+}

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -420,18 +420,18 @@ namespace Bandwidth.Net
   }
 
   /// <summary>
-  /// Helper for HttpResponseMessage to parse CallbackEvent
+  /// Helper for HttpContent to parse CallbackEvent
   /// </summary>
   public static class CallbackEventHelpers
   {
     /// <summary>
-    /// Read CallbackEvent instance from response content
+    /// Read CallbackEvent instance from http content
     /// </summary>
-    /// <param name="response">Response</param>
+    /// <param name="content">Content</param>
     /// <returns>Callback event data or null if response content is not json</returns>
-    public static Task<CallbackEvent> ReadAsCallbackEventAsync(this HttpResponseMessage response)
+    public static Task<CallbackEvent> ReadAsCallbackEventAsync(this HttpContent content)
     {
-      return response.ReadAsJsonAsync<CallbackEvent>();
+      return content.ReadAsJsonAsync<CallbackEvent>();
     }
   }
 }

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -14,7 +14,7 @@ namespace Bandwidth.Net
   /// var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"sms\"}");
   /// switch(callbackEvent.EventType)
   /// {
-  ///   case CallbackEventTypes.Sms:
+  ///   case CallbackEventType.Sms:
   ///     Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
   ///     break;
   /// }
@@ -445,7 +445,7 @@ namespace Bandwidth.Net
     /// var callbackEvent = await response.Content.ReadAsCallbackEventAsync(); // response is instance of HttpResponseEvent
     /// switch(callbackEvent.EventType)
     /// {
-    ///   case CallbackEventTypes.Sms:
+    ///   case CallbackEventType.Sms:
     ///     Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
     ///     break;
     /// }

--- a/src/Bandwidth.Net/CallbackEvent.cs
+++ b/src/Bandwidth.Net/CallbackEvent.cs
@@ -442,7 +442,7 @@ namespace Bandwidth.Net
     /// <returns>Callback event data or null if response content is not json</returns>
     /// <example>
     /// <code>
-    /// var callbackEvent = await response.Content.ReadAsCallbackEventAsync(); // response is instance of HttpResponseEvent
+    /// var callbackEvent = await response.Content.ReadAsCallbackEventAsync(); // response is instance of HttpResponseMessage
     /// switch(callbackEvent.EventType)
     /// {
     ///   case CallbackEventType.Sms:

--- a/src/Bandwidth.Net/Client.cs
+++ b/src/Bandwidth.Net/Client.cs
@@ -132,7 +132,7 @@ namespace Bandwidth.Net
     {
       using (var response = await MakeJsonRequestAsync(method, path, cancellationToken, query, body))
       {
-        return await response.ReadAsJsonAsync<T>();
+        return await response.Content.ReadAsJsonAsync<T>();
       }
     }
 

--- a/src/Bandwidth.Net/JsonHelpers.cs
+++ b/src/Bandwidth.Net/JsonHelpers.cs
@@ -50,11 +50,11 @@ namespace Bandwidth.Net
       }
     }
 
-    public static async Task<TResult> ReadAsJsonAsync<TResult>(this HttpResponseMessage response)
+    public static async Task<TResult> ReadAsJsonAsync<TResult>(this HttpContent content)
     {
-      if (response.Content.Headers.ContentType.MediaType == "application/json")
+      if (content.Headers.ContentType.MediaType == "application/json")
       {
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await content.ReadAsStringAsync();
         return json.Length > 0
             ? JsonConvert.DeserializeObject<TResult>(json, GetSerializerSettings())
             : default(TResult);

--- a/src/Bandwidth.Net/JsonStringEnumConverter.cs
+++ b/src/Bandwidth.Net/JsonStringEnumConverter.cs
@@ -10,10 +10,10 @@ namespace Bandwidth.Net
   {
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
     {
-      // convert string like "enum-value" to EnumType.EnumValue
+      // convert string like "enum-value" and "eNUM-VALUE" to EnumType.EnumValue
       var rawString = (string)reader.Value;
       var result = string.Join("",
-        rawString.Split('-').Select(v => $"{char.ToUpperInvariant(v[0])}{v.Substring(1)}"));
+        rawString.Split('-').Select(v => $"{char.ToUpperInvariant(v[0])}{v.Substring(1).ToLowerInvariant()}"));
       return Enum.Parse(objectType, result);
     }
 

--- a/src/Bandwidth.Net/JsonStringEnumConverter.cs
+++ b/src/Bandwidth.Net/JsonStringEnumConverter.cs
@@ -13,7 +13,7 @@ namespace Bandwidth.Net
       // convert string like "enum-value" and "eNUM-VALUE" to EnumType.EnumValue
       var rawString = (string)reader.Value;
       var result = string.Join("",
-        rawString.Split('-').Select(v => $"{char.ToUpperInvariant(v[0])}{v.Substring(1).ToLowerInvariant()}"));
+        rawString.ToLowerInvariant().Replace('_', '-').Split('-').Select(v => $"{char.ToUpperInvariant(v[0])}{v.Substring(1)}"));
       return Enum.Parse(objectType, result);
     }
 

--- a/src/Bandwidth.Net/LazyEnumerable.cs
+++ b/src/Bandwidth.Net/LazyEnumerable.cs
@@ -29,7 +29,7 @@ namespace Bandwidth.Net
         using (var response = getData().Result)
         {
 
-          var list = response.ReadAsJsonAsync<T[]>().Result;
+          var list = response.Content.ReadAsJsonAsync<T[]>().Result;
           foreach (var item in list)
           {
             yield return item;

--- a/test/Bandwidth.Net.Test/CallbackEventTests.cs
+++ b/test/Bandwidth.Net.Test/CallbackEventTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Net.Http;
+using Bandwidth.Net.Api;
+using Xunit;
+
+namespace Bandwidth.Net.Test
+{
+  public class CallbackEventTests
+  {
+    [Fact]
+    public void TestCreateFromJson()
+    {
+      var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"speak\", \"state\": \"PLAYBACK_STOP\"}");
+      Assert.Equal(CallbackEventTypes.Speak, callbackEvent.EventType);
+      Assert.Equal(CallbackEventStates.PlaybackStop, callbackEvent.State);
+    }
+
+    [Fact]
+    public void TestCreateFromJson2()
+    {
+      var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"sms\", \"deliveryState\": \"not-delivered\"}");
+      Assert.Equal(CallbackEventTypes.Sms, callbackEvent.EventType);
+      Assert.Equal(MessageDeliveryState.NotDelivered, callbackEvent.DeliveryState);
+    }
+
+    [Fact]
+    public void TestCreateFromJson3()
+    {
+      var callbackEvent = CallbackEvent.CreateFromJson("{}");
+      Assert.Equal(CallbackEventTypes.Unknown, callbackEvent.EventType);
+    }
+  }
+
+  public class CallbackEventHelpersTests
+  {
+    [Fact]
+    public async void TestReadAsCallbackEvent()
+    {
+      var response = new HttpResponseMessage
+      {
+        Content = new JsonContent("{\"eventType\": \"speak\", \"state\": \"PLAYBACK_STOP\"}")
+      };
+
+      var callbackEvent = await response.ReadAsCallbackEventAsync();
+      Assert.Equal(CallbackEventTypes.Speak, callbackEvent.EventType);
+      Assert.Equal(CallbackEventStates.PlaybackStop, callbackEvent.State);
+    }
+  }
+}

--- a/test/Bandwidth.Net.Test/CallbackEventTests.cs
+++ b/test/Bandwidth.Net.Test/CallbackEventTests.cs
@@ -40,7 +40,7 @@ namespace Bandwidth.Net.Test
         Content = new JsonContent("{\"eventType\": \"speak\", \"state\": \"PLAYBACK_STOP\"}")
       };
 
-      var callbackEvent = await response.ReadAsCallbackEventAsync();
+      var callbackEvent = await response.Content.ReadAsCallbackEventAsync();
       Assert.Equal(CallbackEventTypes.Speak, callbackEvent.EventType);
       Assert.Equal(CallbackEventStates.PlaybackStop, callbackEvent.State);
     }

--- a/test/Bandwidth.Net.Test/CallbackEventTests.cs
+++ b/test/Bandwidth.Net.Test/CallbackEventTests.cs
@@ -10,15 +10,15 @@ namespace Bandwidth.Net.Test
     public void TestCreateFromJson()
     {
       var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"speak\", \"state\": \"PLAYBACK_STOP\"}");
-      Assert.Equal(CallbackEventTypes.Speak, callbackEvent.EventType);
-      Assert.Equal(CallbackEventStates.PlaybackStop, callbackEvent.State);
+      Assert.Equal(CallbackEventType.Speak, callbackEvent.EventType);
+      Assert.Equal(CallbackEventState.PlaybackStop, callbackEvent.State);
     }
 
     [Fact]
     public void TestCreateFromJson2()
     {
       var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"sms\", \"deliveryState\": \"not-delivered\"}");
-      Assert.Equal(CallbackEventTypes.Sms, callbackEvent.EventType);
+      Assert.Equal(CallbackEventType.Sms, callbackEvent.EventType);
       Assert.Equal(MessageDeliveryState.NotDelivered, callbackEvent.DeliveryState);
     }
 
@@ -26,7 +26,7 @@ namespace Bandwidth.Net.Test
     public void TestCreateFromJson3()
     {
       var callbackEvent = CallbackEvent.CreateFromJson("{}");
-      Assert.Equal(CallbackEventTypes.Unknown, callbackEvent.EventType);
+      Assert.Equal(CallbackEventType.Unknown, callbackEvent.EventType);
     }
   }
 
@@ -41,8 +41,8 @@ namespace Bandwidth.Net.Test
       };
 
       var callbackEvent = await response.Content.ReadAsCallbackEventAsync();
-      Assert.Equal(CallbackEventTypes.Speak, callbackEvent.EventType);
-      Assert.Equal(CallbackEventStates.PlaybackStop, callbackEvent.State);
+      Assert.Equal(CallbackEventType.Speak, callbackEvent.EventType);
+      Assert.Equal(CallbackEventState.PlaybackStop, callbackEvent.State);
     }
   }
 }

--- a/test/Bandwidth.Net.Test/JsonHelpersTests.cs
+++ b/test/Bandwidth.Net.Test/JsonHelpersTests.cs
@@ -32,24 +32,18 @@ namespace Bandwidth.Net.Test
     [Fact]
     public async void TestReadAsJsonAsync()
     {
-      using (var response = new HttpResponseMessage())
-      {
-        response.Content = new StringContent("{\"field1\": 100}", Encoding.UTF8, "application/json");
-        var item = await response.ReadAsJsonAsync<TestItem>();
-        Assert.NotNull(item);
-        Assert.Equal(100, item.Field1);
-      }
+      var content = new StringContent("{\"field1\": 100}", Encoding.UTF8, "application/json");
+      var item = await content.ReadAsJsonAsync<TestItem>();
+      Assert.NotNull(item);
+      Assert.Equal(100, item.Field1);
     }
 
     [Fact]
     public async void TestReadAsJsonAsyncForNonJsonContent()
     {
-      using (var response = new HttpResponseMessage())
-      {
-        response.Content = new StringContent("text", Encoding.UTF8, "plain/text");
-        var item = await response.ReadAsJsonAsync<TestItem>();
-        Assert.Null(item);
-      }
+      var content = new StringContent("text", Encoding.UTF8, "plain/text");
+      var item = await content.ReadAsJsonAsync<TestItem>();
+      Assert.Null(item);
     }
 
     [Fact]

--- a/test/Bandwidth.Net.Test/JsonStringEnumConverterTests.cs
+++ b/test/Bandwidth.Net.Test/JsonStringEnumConverterTests.cs
@@ -26,6 +26,14 @@ namespace Bandwidth.Net.Test
     }
 
     [Fact]
+    public void TestReadJson3()
+    {
+      var item = JsonConvert.DeserializeObject<TestItem>("{\"Item\":\"SOME_ANOTHER_VALUE\"}");
+      Assert.Equal(TestEnum.SomeAnotherValue, item.Item);
+    }
+
+
+    [Fact]
     public void TestWriteJson()
     {
       var item = new TestItem {Item = TestEnum.SomeValue};


### PR DESCRIPTION
Usage with ASP.Net Core (and in other web apps based on HttpRequestMessage and HttpResponseMessage)
```csharp
     var callbackEvent = await request.Content.ReadAsCallbackEventAsync(); // request is instance of HttpRequestMessage
     switch(callbackEvent.EventType)
     {
       case CallbackEventType.Sms:
         Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
         break;
     }
```
Other cases
```csharp
     var callbackEvent = CallbackEvent.CreateFromJson("{\"eventType\": \"sms\"}");
     switch(callbackEvent.EventType)
     {
       case CallbackEventType.Sms:
         Console.WriteLine($"Sms {callbackEvent.From} -> {callbackEvent.To}: {callbackEvent.Text}");
         break;
     }
```